### PR TITLE
Added Jitpack Support

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+  - sdk install java 21.0.8-tem
+  - sdk use java 21.0.8-tem


### PR DESCRIPTION
This PR adds the jitpack support for your excellent work, so that developers want to integrate with productivemetalworks can use jitpack to include it, which can also provide source jars.

But even with this, there's still something not working, because productivelib is also missing, and your repository seems not updated to the latest version that you released. Can you please update it? And I'll open another PR for jitpack in that repo.


For developers who want to include this project, you need to exclude the productivelib somehow, like:

```
compileOnly("com.github.JDKDigital:productivemetalworks:VERSION") {
    exclude group: "local.libs"
}
```